### PR TITLE
Unit-tests for AttibuteContainer

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -40,7 +40,8 @@ message (STATUS "${libname}: UNICODE=${UNICODE} SQL_WCHART_CONVERT=${SQL_WCHART_
 
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/config_cmake.h.in ${CMAKE_CURRENT_BINARY_DIR}/config_cmake${_config_add}.h)
 
-add_library(${libname} SHARED
+# In order to enable testing, put every non-public symbol to a static library (which is then used by shared library and unit-test binary).
+add_library(${libname}_static STATIC
     attr.cpp
     attributes.cpp
     config.cpp
@@ -51,7 +52,6 @@ add_library(${libname} SHARED
     environment.cpp
     handles.cpp
     info.cpp
-    odbc.cpp
     object.cpp
     read_helpers.cpp
     result_set.cpp
@@ -81,31 +81,35 @@ add_library(${libname} SHARED
     ${WIN_SOURCES}
 )
 
+add_library(${libname} SHARED
+    odbc.cpp
+)
+
 
 if (UNICODE)
-    target_compile_definitions(${libname} PUBLIC -DUNICODE=1 -D_UNICODE=1)
+    target_compile_definitions(${libname}_static PUBLIC -DUNICODE=1 -D_UNICODE=1)
     # Mode for unixodbc for working with wchar as in iodbc
     if (SQL_WCHART_CONVERT)
-        target_compile_definitions(${libname} PUBLIC -DSQL_WCHART_CONVERT=1)
+        target_compile_definitions(${libname}_static PUBLIC -DSQL_WCHART_CONVERT=1)
     endif ()
     #if(ODBC_IODBC)
     #    target_compile_definitions(${libname} PUBLIC -DSQL_NOUNICODEMAP=1)
     #endif()
 endif ()
 
-target_compile_definitions (${libname} PRIVATE "-DCMAKE_BUILD=1")
+target_compile_definitions (${libname}_static PUBLIC "-DCMAKE_BUILD=1")
 
-target_include_directories (${libname} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (${libname}_static PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 #if (NOT USE_INTERNAL_POCO_LIBRARY)
-    target_include_directories (${libname} PRIVATE ${Poco_INCLUDE_DIRS})
+    target_include_directories (${libname}_static PRIVATE ${Poco_INCLUDE_DIRS})
 #endif()
 
 if (NOT WIN32)
-    target_include_directories (${libname} PRIVATE ${ODBC_INCLUDE_DIRECTORIES})
+    target_include_directories (${libname}_static PUBLIC ${ODBC_INCLUDE_DIRECTORIES})
 endif()
 
-target_link_libraries(${libname} PRIVATE clickhouse-odbc-escaping)
+target_link_libraries(${libname} PRIVATE ${libname}_static clickhouse-odbc-escaping)
 
 if(USE_SSL)
     target_link_libraries(${libname} PRIVATE ${Poco_NetSSL_LIBRARY} ${Poco_Crypto_LIBRARY} ${Poco_Util_LIBRARY})

--- a/driver/attributes.h
+++ b/driver/attributes.h
@@ -27,17 +27,30 @@ public:
     bool has_attr_string(int attr) const;
     bool has_attr(int attr) const;
 
+    template <typename T> inline bool has_attr_as(int attr) const;
+
     template <typename T> inline T get_attr_as(int attr) const;
 
     template <typename T> inline void set_attr_silent(int attr, const T& value);
     template <typename T> inline void set_attr(int attr, const T& value);
 
+protected:
     virtual void on_attr_change(int attr);
 
 private:
     std::unordered_map<int, std::int64_t> integers;
     std::unordered_map<int, std::string> strings;
 };
+
+template <typename T>
+inline bool AttributeContainer::has_attr_as(int attr) const {
+    return has_attr_integer(attr);
+}
+
+template <>
+inline bool AttributeContainer::has_attr_as<std::string>(int attr) const {
+    return has_attr_string(attr);
+}
 
 template <typename T>
 inline T AttributeContainer::get_attr_as(int attr) const {

--- a/driver/ut/AttributeContainer_test.cpp
+++ b/driver/ut/AttributeContainer_test.cpp
@@ -1,0 +1,136 @@
+#include <attributes.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+TEST(AttributeContainer, Empty)
+{
+    AttributeContainer container;
+
+    EXPECT_FALSE(container.has_attr(0));
+    EXPECT_FALSE(container.has_attr_string(0));
+    EXPECT_FALSE(container.has_attr_integer(0));
+
+    EXPECT_EQ(0, container.get_attr_as<int>(0));
+    EXPECT_EQ(std::string{}, container.get_attr_as<std::string>(0));
+}
+
+template <typename T>
+struct Param
+{
+    using Type = T;
+    using OtherType = std::string;
+
+    const Type VALUE = std::numeric_limits<T>::max();
+    const Type OTHER_VALUE = std::numeric_limits<T>::min();
+};
+
+template <>
+struct Param<std::string>
+{
+    using Type = std::string;
+    using OtherType = int;
+
+    const Type VALUE = "STRING VALUE";
+    const Type OTHER_VALUE = "ANOTHER STRING VALUE";
+};
+
+template <typename T>
+class AttributeContainerT : public ::testing::Test
+{
+};
+
+//using MyTypes = ::testing::Types<int, std::string>;
+typedef ::testing::Types<int, std::string> MyTypes;
+TYPED_TEST_CASE(AttributeContainerT, MyTypes);
+
+TYPED_TEST(AttributeContainerT, SetAttribute)
+{
+    // This should go to fixture, but that makes it akward to use (requires 'this->' on KEY, VALUE, etc.).
+    using Type = typename Param<TypeParam>::Type;
+    using OtherType = typename Param<TypeParam>::OtherType;
+    const int KEY = 1;
+    const TypeParam VALUE = Param<TypeParam>{}.VALUE;
+    const TypeParam OTHER_VALUE = Param<TypeParam>{}.OTHER_VALUE;
+
+    AttributeContainer container;
+
+    EXPECT_NO_THROW(container.set_attr(KEY, VALUE));
+
+    EXPECT_TRUE(container.has_attr(KEY));
+    EXPECT_TRUE(container.has_attr_as<Type>(KEY));
+    EXPECT_FALSE(container.has_attr_as<OtherType>(KEY));
+
+    EXPECT_EQ(VALUE, container.get_attr_as<Type>(KEY));
+    EXPECT_EQ(OtherType{}, container.get_attr_as<OtherType>(KEY));
+}
+
+TYPED_TEST(AttributeContainerT, ResetAttribute)
+{
+    using Type = typename Param<TypeParam>::Type;
+    using OtherType = typename Param<TypeParam>::OtherType;
+    const int KEY = 1;
+    const TypeParam VALUE = Param<TypeParam>{}.VALUE;
+    const TypeParam OTHER_VALUE = Param<TypeParam>{}.OTHER_VALUE;
+
+    AttributeContainer container;
+
+    EXPECT_NO_THROW(container.set_attr(KEY, VALUE));
+    EXPECT_NO_THROW(container.set_attr(KEY, OTHER_VALUE));
+
+    EXPECT_TRUE(container.has_attr(KEY));
+    EXPECT_TRUE(container.has_attr_as<Type>(KEY));
+    EXPECT_FALSE(container.has_attr_as<OtherType>(KEY));
+
+    EXPECT_EQ(OTHER_VALUE, container.get_attr_as<Type>(KEY));
+    EXPECT_EQ(OtherType{}, container.get_attr_as<OtherType>(KEY));
+}
+
+class AttributeContainerTrackingAttributeChange : public AttributeContainer
+{
+public:
+    std::vector<int> changed_attributes;
+
+    void on_attr_change(int attr) override
+    {
+        changed_attributes.push_back(attr);
+    }
+};
+
+TYPED_TEST(AttributeContainerT, SetAttributeCallBack)
+{
+    const int KEY = 1;
+    const TypeParam VALUE = Param<TypeParam>{}.VALUE;
+    const TypeParam OTHER_VALUE = Param<TypeParam>{}.OTHER_VALUE;
+
+    AttributeContainerTrackingAttributeChange container;
+
+    EXPECT_NO_THROW(container.set_attr(KEY, VALUE));
+    ASSERT_EQ(1, container.changed_attributes.size());
+    EXPECT_EQ(KEY, container.changed_attributes.back());
+
+    EXPECT_NO_THROW(container.set_attr(KEY, VALUE));
+    ASSERT_EQ(2, container.changed_attributes.size());
+    EXPECT_EQ(KEY, container.changed_attributes.back());
+
+    const auto NEW_KEY = KEY + 1;
+    EXPECT_NO_THROW(container.set_attr(NEW_KEY, VALUE));
+    ASSERT_EQ(3, container.changed_attributes.size());
+    EXPECT_EQ(NEW_KEY, container.changed_attributes.back());
+}
+
+TYPED_TEST(AttributeContainerT, SetAttributeSilentCallBack)
+{
+    const int KEY = 1;
+    const TypeParam VALUE = Param<TypeParam>{}.VALUE;
+    const TypeParam OTHER_VALUE = Param<TypeParam>{}.OTHER_VALUE;
+
+    AttributeContainerTrackingAttributeChange container;
+
+    EXPECT_NO_THROW(container.set_attr_silent(KEY, VALUE));
+    ASSERT_EQ(0, container.changed_attributes.size());
+
+    EXPECT_NO_THROW(container.set_attr_silent(KEY, OTHER_VALUE));
+    ASSERT_EQ(0, container.changed_attributes.size());
+}

--- a/driver/ut/CMakeLists.txt
+++ b/driver/ut/CMakeLists.txt
@@ -4,11 +4,13 @@ add_executable(clickhouse-odbc-ut
     main.cpp
     escape_sequences_ut.cpp
     lexer_ut.cpp
+    AttributeContainer_test.cpp
 )
 
 target_link_libraries(clickhouse-odbc-ut
     PRIVATE
     clickhouse-odbc-escaping
+    clickhouse-odbc_static
     gtest-lib
     Threads::Threads
 )

--- a/driver/utils.h
+++ b/driver/utils.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <algorithm>
+#include <functional>
 #include <chrono>
 #include <iomanip>
 #include <sstream>


### PR DESCRIPTION
Building all non-visible symbols of ODBC driver as static library to allow testing.
Added tests fro AtributeContainer.